### PR TITLE
v0.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-recipe-manager" %}
-{% set version = "0.4.1" %}
+{% set version = "0.4.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda-incubator/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 40071212e6838117d1d0cba3c0897a9fbd8541440bb789ee8fa430715bf63df7
+  sha256: dc4ae26ea96ab70e33fc9828f0a445e186a2c4869de87775ab01554420805ce1
 
 build:
   number: 0


### PR DESCRIPTION
No ticket number, this replicates the changes I made to the conda-forge upstream.

I need this change so that the recipe bumper bot may use the latest fixes.