### PR TITLE
v0.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,6 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  license_url: https://github.com/anaconda/conda-recipe-manager/blob/main/LICENSE
   summary: Helper tool for recipes on aggregate.
   description: |
     Renders local recipes, provides build orders, find outdated recipes.
@@ -81,5 +80,7 @@ about:
   dev_url: https://github.com/conda/conda-recipe-manager
 
 extra:
+  skip-lints:
+    - avoid_noarch
   recipe-maintainers:
     - schuylermartin45

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-recipe-manager" %}
-{% set version = "0.4.2" %}
+{% set version = "0.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: dc4ae26ea96ab70e33fc9828f0a445e186a2c4869de87775ab01554420805ce1
+  sha256: ee27af3bc41a2779d88c680761a33eb101527e9d78233e637c0aa7c5b2f7ff7d
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: {{PYTHON}} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:


### PR DESCRIPTION
CRM v0.5.0

**Destination channel:** defaults

### Links

- [GitHub Issue](https://github.com/conda/conda-recipe-manager/issues/335) 
- [Upstream repository](https://github.com/conda/conda-recipe-manager)
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - CRM's development recipe switched to `matplotlib-base` but this recipe already used that

### Explanation of changes:

- CRM upgraded to v0.5.0, which is needed for current automation initiatives.
