### PR TITLE
Fixes a version issue with Click that I realized this morning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 12a3b6f0aa75a7217bff70121d7521c8944579ccc3f902657f6c07acc73ee4f6
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{PYTHON}} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
@@ -25,7 +25,7 @@ requirements:
     - wheel
   run:
     - python >=3.11
-    - click <8.2.0
+    - click >=8.1.7,<8.2.0
     - conda
     - jinja2
     - pyyaml


### PR DESCRIPTION
This fixes a small version constraint issue I realized this morning. Technically, if they installed a version of Click older than 8.1.7, the user may experience some issues. This should not have been wiped when the newer `<8.2.0` constraint was put in on the last release.